### PR TITLE
chore: Reapply api key field validation

### DIFF
--- a/src/ExternalSearch.Providers.BvD/Constants.cs
+++ b/src/ExternalSearch.Providers.BvD/Constants.cs
@@ -65,9 +65,8 @@ public static class Constants
                 IsRequired = true,
                 Name = KeyName.ApiToken,
                 Help = "The key to authenticate access to the BvD API.",
-                // TODO Reapply validation in 4.5.0 onwards
-                //ValidationRules =
-                //    [new() { { "regex", "\\s" }, { "message", "Spaces are not allowed" } }]
+                ValidationRules =
+                    [new() { { "regex", "\\s" }, { "message", "Spaces are not allowed" } }]
             },
             new()
             {


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description

Reapply the api key control validation (no space allowed) since BvD enricher is targeting 4.5 now.

## How has it been tested? <!-- Remove if not needed -->
Manually in local
