### PR TITLE
fix: Make auto match toggle usable without relying on validate bvd id toggle

### DIFF
--- a/ExternalSearch.Providers.BvD.sln.DotSettings
+++ b/ExternalSearch.Providers.BvD.sln.DotSettings
@@ -1,9 +1,11 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=Id/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=empl/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=GIIN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ICIJ/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISIN/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NACE/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=NAICS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=opre/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ORBISID/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=USSIC/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/docs/4.4.2-release-notes.md
+++ b/docs/4.4.2-release-notes.md
@@ -1,0 +1,7 @@
+# Features
+- Preregister Number of Employee, Operating Revenue and Score Vocabulary Key
+
+# Fix
+- Resolve unable to enrich entity with empty BvD ID
+- Make the Auto Enrich toggle usable independently, without relying on the Validate BvD ID toggle
+

--- a/docs/4.4.2-release-notes.md
+++ b/docs/4.4.2-release-notes.md
@@ -1,5 +1,5 @@
 # Features
-- Preregister Number of Employee, Operating Revenue and Score Vocabulary Key
+- Preregister Number of Employee, Operating Revenue, Score and Hint Vocabulary Key
 
 # Fix
 - Resolve unable to enrich entity with empty BvD ID

--- a/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
@@ -95,6 +95,12 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         IDictionary<string, object> config, IProvider provider)
     {
         var jobData = new BvDExternalSearchJobData(config);
+
+        if (string.IsNullOrEmpty(jobData.BvDId))
+        {
+            jobData.ValidateBvDId = false; // TODO The toggle is not set to false if hidden in UI
+        }
+
         return InternalExecuteSearch(context, query, jobData.ApiToken, jobData.SelectProperties, jobData);
     }
 
@@ -383,23 +389,29 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
 
             var filteredValues = bvdId.Where(v => !bvd(v)).ToArray();
 
-            if (!filteredValues.Any())
+            if (bvdId.Count > 0 && !filteredValues.Any())
             {
                 context.Log.LogWarning("Filter removed all BvD numbers, skipping processing. Original '{Original}'",
                     string.Join(",", bvdId));
             }
             else
             {
-                foreach (var value in filteredValues)
+                if (filteredValues.Any())
                 {
-                    request.CustomQueryInput = bvdId.ElementAt(0);
+                    foreach (var value in filteredValues)
+                    {
+                        context.Log.LogInformation(
+                            "External search query produced, ExternalSearchQueryParameter: '{Identifier}' EntityType: '{EntityCode}' Value: '{SanitizedValue}'",
+                            ExternalSearchQueryParameter.Identifier, entityType.Code, value);
 
-                    context.Log.LogInformation(
-                        "External search query produced, ExternalSearchQueryParameter: '{Identifier}' EntityType: '{EntityCode}' Value: '{SanitizedValue}'",
-                        ExternalSearchQueryParameter.Identifier, entityType.Code, value);
+                        request.CustomQueryInput = bvdId.ElementAt(0);
+                        conditions.Add("BvDId", value);
 
-                    conditions.Add("BvDId", value);
-
+                        yield return new ExternalSearchQuery(this, entityType, conditions);
+                    }
+                }
+                else
+                {
                     yield return new ExternalSearchQuery(this, entityType, conditions);
                 }
             }
@@ -439,34 +451,31 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
 
             var client = new RestClient("https://api.bvdinfo.com/v1/orbis/Companies");
 
-            // If validate bvd id toggle is enabled, get the list of possible match companies for validation,
-            // else use the original bvd id provided
-            if (jobData.ValidateBvDId)
+            // If bvd id is not null and both validate bvd id and auto match toggles are disabled.
+            if (!string.IsNullOrEmpty(bvd) && !jobData.ValidateBvDId && !jobData.MatchFirstAndHighest)
             {
-                var matchCompanies = GetMatchCompanies(context, query, jobData, client);
+                var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client, bvd);
+                searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
 
-                // If bvd id not exist in the list of possible match companies
-                if (matchCompanies is not { Count: > 0 } || !matchCompanies.Exists(x => x.BvDId == bvd)) 
+                yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
+                yield break;
+            }
+
+            var matchCompanies = GetMatchCompanies(context, query, jobData, client);
+
+            if (string.IsNullOrEmpty(bvd))
+            {
+                if (!matchCompanies.Any())
                 {
-                    if (!matchCompanies.Any())
-                    {
-                        yield break;
-                    }
+                    context.Log.LogInformation($"No match found when auto-match enabled. Skipping search execution - {Name}.");
+                    yield break;
+                }
 
-                    // If auto match first and highest confidence score match toggle is enabled, search using the bvd id of first match
-                    if (jobData.MatchFirstAndHighest)
+                if (!jobData.MatchFirstAndHighest)
+                {
+                    if (jobData.ValidateBvDId)
                     {
-                        var firstMatchCompany = matchCompanies.FirstOrDefault();
-
-                        var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client,
-                            firstMatchCompany?.BvDId);
-                        searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
-
-                        yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
-                    }
-                    else 
-                    {
-                        // else return list of possible match json
+                        // Return list of possible match json
                         var rawMatch = new BvDResponse
                         {
                             SearchSummary = new SearchSummary
@@ -492,24 +501,89 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
 
                         yield return new ExternalSearchQueryResult<BvDResponse>(query, rawMatch);
                     }
-                }
-                else
-                {
-                    // If bvd id exist in the list of possible match companies
-                    var matchCompany = matchCompanies.FirstOrDefault(x => x.BvDId == bvd);
-                    var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client,
-                        matchCompany?.BvDId);
-                    searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
+                    else
+                    {
+                        context.Log.LogInformation($"No bvd id provided with auto-match disabled. Skipping search execution - {Name}.");
+                    }
 
-                    yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
+                    yield break;
                 }
+
+                // If there is no bvd id and auto match toggle is enabled, search using the bvd id of first match
+                var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client, matchCompanies.FirstOrDefault()?.BvDId);
+                searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompany.Data.First().Add("Score", matchCompanies.FirstOrDefault()?.Score);
+
+                yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
+                yield break;
             }
-            else
+
+            // Enrich if bvd id (not empty) is provided and validate bvd id toggle is disabled
+            if (!jobData.ValidateBvDId)
             {
                 var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client, bvd);
                 searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
 
                 yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
+                yield break;
+            }
+
+            // Validation starts
+            if (!matchCompanies.Any())
+            {
+                context.Log.LogInformation($"No match found for validation. Skipping search execution - {Name}.");
+                yield break;
+            }
+
+            // If bvd id exist in the list of possible match companies (PASS)
+            if (matchCompanies.Exists(x => x.BvDId == bvd))
+            {
+                var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client,
+                    bvd);
+                searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompany.Data.First().Add("Score", matchCompanies.FirstOrDefault()?.Score);
+
+                yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
+                yield break;
+            }
+
+            // If bvd id not exist in the list of possible match companies (FAILED)
+            // If auto match toggle is enabled, search using the bvd id of first match
+            if (jobData.MatchFirstAndHighest)
+            {
+                var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client, matchCompanies.FirstOrDefault()?.BvDId);
+                searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompany.Data.First().Add("Score", matchCompanies.FirstOrDefault()?.Score);
+
+                yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
+            }
+            else
+            {
+                // else return list of possible match json
+                var rawMatch = new BvDResponse
+                {
+                    SearchSummary = new SearchSummary
+                    {
+                        TotalRecordsFound = 0,
+                        Offset = 0,
+                        RecordsReturned = 0,
+                        DatabaseInfo = null,
+                        Sort = null
+                    },
+                    Data =
+                    [
+                        new Dictionary<string, object>
+                    {
+                        {"RawMatches", JsonConvert.SerializeObject(matchCompanies, new JsonSerializerSettings
+                        {
+                            NullValueHandling = NullValueHandling.Ignore
+                        })},
+                        {"BvdIdNeedsAttention", true}
+                    }
+                    ]
+                };
+
+                yield return new ExternalSearchQueryResult<BvDResponse>(query, rawMatch);
             }
         }
     }

--- a/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
@@ -512,6 +512,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                 // If there is no bvd id and auto match toggle is enabled, search using the bvd id of first match
                 var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client, matchCompanies.FirstOrDefault()?.BvDId);
                 searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompany.Data.First().Add("Hint", matchCompanies.FirstOrDefault()?.Hint);
                 searchCompany.Data.First().Add("Score", matchCompanies.FirstOrDefault()?.Score);
 
                 yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
@@ -541,6 +542,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                 var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client,
                     bvd);
                 searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompany.Data.First().Add("Hint", matchCompanies.FirstOrDefault()?.Hint);
                 searchCompany.Data.First().Add("Score", matchCompanies.FirstOrDefault()?.Score);
 
                 yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
@@ -553,6 +555,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             {
                 var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client, matchCompanies.FirstOrDefault()?.BvDId);
                 searchCompany.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompany.Data.First().Add("Hint", matchCompanies.FirstOrDefault()?.Hint);
                 searchCompany.Data.First().Add("Score", matchCompanies.FirstOrDefault()?.Score);
 
                 yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);

--- a/src/ExternalSearch.Providers.BvD/Constants.cs
+++ b/src/ExternalSearch.Providers.BvD/Constants.cs
@@ -86,6 +86,33 @@ public static class Constants
         //},
         new()
         {
+            DisplayName = "Validate BvD ID",
+            Type = "checkbox",
+            IsRequired = false,
+            Name = KeyName.ValidateBvDId,
+            Help =
+                "Toggle to control whether the BvD ID needs to be validated before enrichment.",
+            DisplayDependencies =
+            [
+                new ControlDisplayDependency
+                {
+                    Name = KeyName.BvDId,
+                    Operator = ControlDependencyOperator.Exists,
+                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                }
+            ],
+        },
+        new()
+        {
+            DisplayName = "Auto Enrich with First and Highest Score Match",
+            Type = "checkbox",
+            IsRequired = false,
+            Name = KeyName.MatchFirstAndHighest,
+            Help =
+                "Toggle to control whether the enrichment should be based on the first and highest score match if BvD ID validation failed or BvD ID is empty.",
+        },
+        new()
+        {
             DisplayName = "Enrichment properties",
             Type = "input",
             IsRequired = false,
@@ -95,48 +122,12 @@ public static class Constants
         },
         new()
         {
-            DisplayName = "Validate BvD ID",
-            Type = "checkbox",
-            IsRequired = false,
-            Name = KeyName.ValidateBvDId,
-            Help =
-                "Toggle to control whether the BvD ID needs to be validated before enrichment."
-        },
-        new()
-        {
-            DisplayName = "Auto Enrich with First and Highest Score Match",
-            Type = "checkbox",
-            IsRequired = false,
-            Name = KeyName.MatchFirstAndHighest,
-            Help =
-                "Toggle to control whether the enrichment should be based on the first and highest score match if BvD ID validation failed.",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
-        },
-        new()
-        {
             DisplayName = "Score Limit",
             Type = "input",
             IsRequired = true,
             Name = KeyName.ScoreLimit,
             Help =
                 "The score limit required for matches to be considered in the validation process. (e.g., if you enter 0.5, only matches with scores more than 0.5 will be used for validation).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -146,15 +137,6 @@ public static class Constants
             Name = KeyName.Name,
             Help =
                 "The vocabulary key that contains the names of companies you want to enrich (e.g., organization.name).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -164,15 +146,6 @@ public static class Constants
             Name = KeyName.Country,
             Help =
                 "The vocabulary key that contains the countries of companies you want to enrich (e.g., organization.address.country).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -182,15 +155,6 @@ public static class Constants
             Name = KeyName.Address,
             Help =
                 "The vocabulary key that contains the addresses of companies you want to enrich (e.g., organization.address).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -200,15 +164,6 @@ public static class Constants
             Name = KeyName.City,
             Help =
                 "The vocabulary key that contains the cities of companies you want to enrich (e.g., organization.address.city).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -218,15 +173,6 @@ public static class Constants
             Name = KeyName.PostCode,
             Help =
                 "The vocabulary key that contains the post codes of companies you want to enrich (e.g., organization.address.postCode).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -236,15 +182,6 @@ public static class Constants
             Name = KeyName.State,
             Help =
                 "The vocabulary key that contains the states of companies you want to enrich (e.g., organization.address.state).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -254,15 +191,6 @@ public static class Constants
             Name = KeyName.Website,
             Help =
                 "The vocabulary key that contains the websites of companies you want to enrich (e.g., organization.website).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -272,15 +200,6 @@ public static class Constants
             Name = KeyName.Email,
             Help =
                 "The vocabulary key that contains the emails of companies you want to enrich (e.g., organization.contact.email).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -290,15 +209,6 @@ public static class Constants
             Name = KeyName.Phone,
             Help =
                 "The vocabulary key that contains the phone numbers of companies you want to enrich (e.g., organization.phoneNumber).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -308,15 +218,6 @@ public static class Constants
             Name = KeyName.Fax,
             Help =
                 "The vocabulary key that contains the fax numbers of companies you want to enrich (e.g., organization.fax).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -326,15 +227,6 @@ public static class Constants
             Name = KeyName.NationalId,
             Help =
                 "The vocabulary key that contains the national IDs of companies you want to enrich (e.g., organization.nationalId).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -344,15 +236,6 @@ public static class Constants
             Name = KeyName.Ticker,
             Help =
                 "The vocabulary key that contains the ticker symbols of companies you want to enrich (e.g., organization.ticker).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
         new()
         {
@@ -362,15 +245,6 @@ public static class Constants
             Name = KeyName.Isin,
             Help =
                 "The vocabulary key that contains the ISIN codes of companies you want to enrich (e.g., organization.isin).",
-            DisplayDependencies =
-            [
-                new ControlDisplayDependency
-                {
-                    Name = KeyName.ValidateBvDId,
-                    Operator = ControlDependencyOperator.Exists,
-                    UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
-                }
-            ],
         },
     };
 

--- a/src/ExternalSearch.Providers.BvD/Vocabularies/BvDOrganizationVocabulary.cs
+++ b/src/ExternalSearch.Providers.BvD/Vocabularies/BvDOrganizationVocabulary.cs
@@ -158,6 +158,9 @@ public class BvDOrganizationVocabulary : SimpleVocabulary
             GuoBvdIdNumber = group.Add(new VocabularyKey("guoBvdIdNumber"));
             RawMatches = group.Add(new VocabularyKey("rawMatches"));
             BvdIdNeedsAttention = group.Add(new VocabularyKey("bvdIdNeedsAttention"));
+            NumberOfEmployee = group.Add(new VocabularyKey("empl"));
+            OperatingRevenue = group.Add(new VocabularyKey("opre"));
+            Score = group.Add(new VocabularyKey("score"));
         });
     }
 
@@ -292,4 +295,7 @@ public class BvDOrganizationVocabulary : SimpleVocabulary
     public VocabularyKey GuoBvdIdNumber { get; protected set; }
     public VocabularyKey RawMatches { get; protected set; }
     public VocabularyKey BvdIdNeedsAttention { get; protected set; }
+    public VocabularyKey NumberOfEmployee { get; protected set; }
+    public VocabularyKey OperatingRevenue { get; protected set; }
+    public VocabularyKey Score { get; protected set; }
 }

--- a/src/ExternalSearch.Providers.BvD/Vocabularies/BvDOrganizationVocabulary.cs
+++ b/src/ExternalSearch.Providers.BvD/Vocabularies/BvDOrganizationVocabulary.cs
@@ -161,6 +161,7 @@ public class BvDOrganizationVocabulary : SimpleVocabulary
             NumberOfEmployee = group.Add(new VocabularyKey("empl"));
             OperatingRevenue = group.Add(new VocabularyKey("opre"));
             Score = group.Add(new VocabularyKey("score"));
+            Hint = group.Add(new VocabularyKey("hint"));
         });
     }
 
@@ -298,4 +299,5 @@ public class BvDOrganizationVocabulary : SimpleVocabulary
     public VocabularyKey NumberOfEmployee { get; protected set; }
     public VocabularyKey OperatingRevenue { get; protected set; }
     public VocabularyKey Score { get; protected set; }
+    public VocabularyKey Hint { get; protected set; }
 }


### PR DESCRIPTION
… toggle

<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#47858](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47858)
Work Item ID: [AB#47859](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/47859)

## How has it been tested? <!-- Remove if not needed -->
Manually in local
