### PR TITLE
fix: Register bvdIdNeedsAttention vocab key without throwing an exception

### DIFF
--- a/docs/4.5.0-release-notes.md
+++ b/docs/4.5.0-release-notes.md
@@ -6,3 +6,4 @@
 # Fix
 - Mask and rename enricher configuration api key field
 - Display the only element in array as plain text
+- Register the bvdIdNeedsAttention vocabulary key without throwing an exception

--- a/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
@@ -497,7 +497,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             if (!string.IsNullOrEmpty(bvd) && !isValidateBvDId && !isAutoMatch)
             {
                 //var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client, bvd);
-                searchCompany?.Data?.First().Add("BvdIdNeedsAttention", false);
+                searchCompany?.Data?.First().Add("Bvd_Id_Needs_Attention", false);
 
                 yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
                 yield break;
@@ -536,7 +536,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                                     {
                                         NullValueHandling = NullValueHandling.Ignore
                                     })},
-                                    {"BvdIdNeedsAttention", true}
+                                    {"Bvd_Id_Needs_Attention", true}
                                 }
                             ]
                         };
@@ -553,7 +553,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
 
                 // If there is no bvd id and auto match toggle is enabled, search using the bvd id of first match
                 var searchCompanyFuzzyMatch = SearchCompanies(context, query, apiToken, selectProperties, client, matchCompanies.FirstOrDefault()?.BvDId);
-                searchCompanyFuzzyMatch?.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompanyFuzzyMatch?.Data.First().Add("Bvd_Id_Needs_Attention", false);
                 searchCompanyFuzzyMatch?.Data.First().Add("Hint", matchCompanies.FirstOrDefault()?.Hint);
                 searchCompanyFuzzyMatch?.Data.First().Add("Score", matchCompanies.FirstOrDefault()?.Score);
 
@@ -565,7 +565,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             if (!isValidateBvDId)
             {
                 //var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client, bvd);
-                searchCompany?.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompany?.Data.First().Add("Bvd_Id_Needs_Attention", false);
 
                 yield return new ExternalSearchQueryResult<BvDResponse>(query, searchCompany);
                 yield break;
@@ -583,7 +583,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             {
                 //var searchCompany = SearchCompanies(context, query, apiToken, selectProperties, client,
                 //    bvd);
-                searchCompany?.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompany?.Data.First().Add("Bvd_Id_Needs_Attention", false);
                 searchCompany?.Data.First().Add("Hint", matchCompanies.FirstOrDefault()?.Hint);
                 searchCompany?.Data.First().Add("Score", matchCompanies.FirstOrDefault()?.Score);
 
@@ -596,7 +596,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             if (isAutoMatch)
             {
                 var searchCompanyFuzzyMatch = SearchCompanies(context, query, apiToken, selectProperties, client, matchCompanies.FirstOrDefault()?.BvDId);
-                searchCompanyFuzzyMatch?.Data.First().Add("BvdIdNeedsAttention", false);
+                searchCompanyFuzzyMatch?.Data.First().Add("Bvd_Id_Needs_Attention", false);
                 searchCompanyFuzzyMatch?.Data.First().Add("Hint", matchCompanies.FirstOrDefault()?.Hint);
                 searchCompanyFuzzyMatch?.Data.First().Add("Score", matchCompanies.FirstOrDefault()?.Score);
 
@@ -623,7 +623,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                         {
                             NullValueHandling = NullValueHandling.Ignore
                         })},
-                        {"BvdIdNeedsAttention", true}
+                        {"Bvd_Id_Needs_Attention", true}
                     }
                     ]
                 };


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#50028](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/50028)

Stop hitting this exception when register vocabulary key. The issue is `GetVocabularyKeyByFullName()` is case sensitive while AddVocabularyKey() is case insensitive, causing the vocabulary cannot be found but also cannot be created
![image](https://github.com/user-attachments/assets/71845f93-86b0-469d-ab02-a9b137abec3e)


## How has it been tested? <!-- Remove if not needed -->
Manually in local
