### PR TITLE
fix: Register rawMatches vocab key without throwing an exception

### DIFF
--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -7,3 +7,4 @@
 - Mask and rename enricher configuration api key field
 - Display the only element in array as plain text
 - Register the bvdIdNeedsAttention vocabulary key without throwing an exception
+- Register the rawMatches vocabulary key without throwing an exception

--- a/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
@@ -532,7 +532,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                             [
                                 new Dictionary<string, object>
                                 {
-                                    {"RawMatches", JsonConvert.SerializeObject(matchCompanies, new JsonSerializerSettings
+                                    {"Raw_Matches", JsonConvert.SerializeObject(matchCompanies, new JsonSerializerSettings
                                     {
                                         NullValueHandling = NullValueHandling.Ignore
                                     })},
@@ -619,7 +619,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                     [
                         new Dictionary<string, object>
                     {
-                        {"RawMatches", JsonConvert.SerializeObject(matchCompanies, new JsonSerializerSettings
+                        {"Raw_Matches", JsonConvert.SerializeObject(matchCompanies, new JsonSerializerSettings
                         {
                             NullValueHandling = NullValueHandling.Ignore
                         })},


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#50439

Fix the rawMatches vocabulary key failed to dynamically register if already exist.

## How has it been tested? <!-- Remove if not needed -->
Manually in local