### PR TITLE
feat: Validate vocabulary keys combination

### DIFF
--- a/docs/4.6.0-release-notes.md
+++ b/docs/4.6.0-release-notes.md
@@ -3,3 +3,4 @@
 
 # Fix
 - Validate Score Limit field
+- Validate the enricher setting combinations

--- a/src/ExternalSearch.Providers.BvD.Provider/BvDSearchProviderProvider.cs
+++ b/src/ExternalSearch.Providers.BvD.Provider/BvDSearchProviderProvider.cs
@@ -49,6 +49,21 @@ public class BvDSearchProviderProvider : ProviderBase, IExtendedProviderMetadata
         { "autoSubmission", false },
         { "dataSourceSetId", string.Empty },
     };
+    public Dictionary<string, HashSet<string>> ValidRequiredFieldConfigurationCombinations => new() {
+        { "Name", [Constants.KeyName.Name] },
+        { "Country", [Constants.KeyName.Country] },
+        { "Address", [Constants.KeyName.Address] },
+        { "City", [Constants.KeyName.City] },
+        { "Post Code", [Constants.KeyName.PostCode] },
+        { "State", [Constants.KeyName.State] },
+        { "Website", [Constants.KeyName.Website] },
+        { "Email", [Constants.KeyName.Email] },
+        { "Phone number", [Constants.KeyName.Phone] },
+        { "Fax number", [Constants.KeyName.Fax] },
+        { "National ID", [Constants.KeyName.NationalId] },
+        { "Ticker", [Constants.KeyName.Ticker] },
+        { "ISIN", [Constants.KeyName.Isin] }
+    };
 
     private static IProviderMetadata GetMetaData()
     {

--- a/src/ExternalSearch.Providers.BvD.Provider/Provider.ExternalSearch.Providers.BvD.csproj
+++ b/src/ExternalSearch.Providers.BvD.Provider/Provider.ExternalSearch.Providers.BvD.csproj
@@ -1,5 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#50615](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/50615)

Added the vocabulary key validation, but didn't include every possible combination because there are too many, just stating vocabulary keys that might be missing in error message
<img width="1900" height="934" alt="image" src="https://github.com/user-attachments/assets/73c5d77b-bbee-4c85-991e-cc7dbeac9019" />

## How has it been tested? <!-- Remove if not needed -->
Manually in local