### PR TITLE
fix: Resolve AddVocabularyKeyAsync object reference is null issue

### DIFF
--- a/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
@@ -1052,7 +1052,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                     IsVisible = true,
                     Storage = VocabularyKeyStorage.Keyword
                 };
-                var vocabKeyId = vocabularyRepository.AddVocabularyKeyAsync(context, newVocabKey).GetAwaiter().GetResult();
+                var vocabKeyId = vocabularyRepository.AddVocabularyKeyAsync(context, newVocabKey, context.Organization.Id, Guid.Empty).GetAwaiter().GetResult();
                 vocabularyRepository.ActivateVocabularyKeyAsync(context, vocabKeyId).GetAwaiter().GetResult();
             }
             context.ApplicationContext.System.Cache.SetItem(cacheKey, new object(), DateTimeOffset.Now.AddMinutes(1));


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#54203](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/54203)

Use overloaded AddVocabularyKeyAsync() that does not get UserId from context. (Missed out this change in previous PR due to package reference is not automatically pointing to latest alpha version)

No release note added in this PR because there is already one similar created before

## How has it been tested? <!-- Remove if not needed -->
Manually in local

