### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,7 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.7.0-alpha.*</_CluedIn>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,18 +9,14 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />
-    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
-    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
-    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0" />
+    <PackageReference Update="CluedIn.Testing.Base" Version="5.0.0-*" />
   </ItemGroup>
   <ItemGroup>
     <!--
@@ -29,7 +24,6 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <!--    <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />-->
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <!--    <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />-->

--- a/Packages.props
+++ b/Packages.props
@@ -24,9 +24,7 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <!--    <PackageReference Update="CluedIn.Crawling" Version="$(_CluedIn)" />-->
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
-    <!--    <PackageReference Update="CluedIn.Core.Agent" Version="$(_CluedIn)" />-->
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.Integration.PrivateServices" Version="$(_CluedIn)" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": "false"
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/ExternalSearch.Providers.BvD.Provider/Provider.ExternalSearch.Providers.BvD.csproj
+++ b/src/ExternalSearch.Providers.BvD.Provider/Provider.ExternalSearch.Providers.BvD.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
-    <PackageReference Include="ComponentHost" />
   </ItemGroup>
 
 

--- a/src/ExternalSearch.Providers.BvD.Provider/Provider.ExternalSearch.Providers.BvD.csproj
+++ b/src/ExternalSearch.Providers.BvD.Provider/Provider.ExternalSearch.Providers.BvD.csproj
@@ -1,12 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
     <PackageReference Include="ComponentHost" />

--- a/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.BvD/BvDExternalSearchProvider.cs
@@ -243,7 +243,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             Select = _selectMatchFields
         };
 
-        var matchRequest = new RestRequest("match", Method.POST);
+        var matchRequest = new RestRequest("match", Method.Post);
         matchRequest.AddHeader("Content-Type", "application/json");
         matchRequest.AddHeader("ApiToken", jobData.ApiToken);
         matchRequest.AddJsonBody(bvdMatchesRequestBody);
@@ -266,7 +266,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                 : null
         };
 
-        var request = new RestRequest("data", Method.POST);
+        var request = new RestRequest("data", Method.Post);
         request.AddHeader("Content-Type", "application/json");
         request.AddHeader("ApiToken", jobData.ApiToken);
         request.AddJsonBody(bvdRequest);
@@ -727,7 +727,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
             Select = _selectMatchFields
         };
 
-        var request = new RestRequest("match", Method.POST);
+        var request = new RestRequest("match", Method.Post);
         request.AddHeader("Content-Type", "application/json");
         request.AddHeader("ApiToken", jobData.ApiToken);
         request.AddJsonBody(bvdRequest);
@@ -808,7 +808,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
                     : null
             };
 
-            var request = new RestRequest("data", Method.POST);
+            var request = new RestRequest("data", Method.Post);
             request.AddHeader("Content-Type", "application/json");
             request.AddHeader("ApiToken", apiToken);
             request.AddJsonBody(bvdRequest);
@@ -873,7 +873,7 @@ public class BvDExternalSearchProvider : ExternalSearchProviderBase, IExtendedEn
         return null;
     }
 
-    private ConnectionVerificationResult ConstructVerifyConnectionResponse<T>(IRestResponse<T> response)
+    private ConnectionVerificationResult ConstructVerifyConnectionResponse<T>(RestResponse<T> response)
     {
         try
         {

--- a/src/ExternalSearch.Providers.BvD/ExternalSearch.Providers.BvD.csproj
+++ b/src/ExternalSearch.Providers.BvD/ExternalSearch.Providers.BvD.csproj
@@ -13,7 +13,4 @@
     <PackageReference Include="CluedIn.ExternalSearch" />
     <PackageReference Include="CluedIn.Integration.PrivateServices" />
   </ItemGroup>
-  <PropertyGroup>
-    <LangVersion>preview</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="coverlet.msbuild" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Shouldly" />

--- a/test/integration/ExternalSearch.BvD.Integration.Tests/Dummy.cs
+++ b/test/integration/ExternalSearch.BvD.Integration.Tests/Dummy.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+namespace CluedIn.ExternalSearch.BvD.Integration.Tests;
+
+public class Dummy
+{
+    [Fact]
+    public void ShouldPass()
+    {
+    }
+}

--- a/test/unit/ExternalSearch.BvD.Unit.Tests/Dummy.cs
+++ b/test/unit/ExternalSearch.BvD.Unit.Tests/Dummy.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+namespace CluedIn.ExternalSearch.BvD.Unit.Tests;
+
+public class Dummy
+{
+    [Fact]
+    public void ShouldPass()
+    {
+    }
+}


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`